### PR TITLE
PB | lwjgl3 upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,12 @@ allprojects {
     version = '1.0'
     ext {
         appName = "glaikunt-framework"
-        gdxVersion = '1.9.14'
+        gdxVersion = '1.11.0'
         roboVMVersion = '2.3.12'
         box2DLightsVersion = '1.5'
         ashleyVersion = '1.7.4'
         aiVersion = '1.8.2'
-        gdxControllersVersion = '2.1.0'
+        gdxControllersVersion = '2.2.1'
     }
 
     repositories {
@@ -45,7 +45,7 @@ project(":desktop") {
 
     dependencies {
         implementation project(":core")
-        api "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
+        api "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
         api "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
         api "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop"
         api "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"

--- a/desktop/src/main/java/com/glaikunt/framework/desktop/DesktopLauncher.java
+++ b/desktop/src/main/java/com/glaikunt/framework/desktop/DesktopLauncher.java
@@ -1,20 +1,26 @@
 package com.glaikunt.framework.desktop;
 
-import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.glaikunt.framework.DynamicDisplay;
 
+/**
+ * Conversion to lwjgl3
+ *  - default libgdx backend version
+ * 	- discontinuation of lwjgl3
+ * 	- better support for JREs, macOS, Linux and muti-window environments
+ * https://libgdx.com/news/2021/07/devlog-7-lwjgl3
+ */
 public class DesktopLauncher {
 	public static void main (String[] arg) {
-		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-		//		config.width = (int) (1440 * .9f);
-//		config.height = (int) (900 * .9f);
-		config.width = 1280;
-		config.height = 960;
-		config.title = "Libgdx Framework";
-		config.resizable = false;
+		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+		config.setTitle("Libgdx Framework");
+		config.useVsync(true);
+		config.setForegroundFPS(60);
+		config.setWindowedMode(1280, 960);
+		config.setResizable(false);
 //		new LwjglApplication(new Display2D(), config);
 //		new LwjglApplication(new Display3D(), config);
-		new LwjglApplication(new DynamicDisplay(), config);
+		new Lwjgl3Application(new DynamicDisplay(), config);
 	}
 }


### PR DESCRIPTION
 * Conversion to lwjgl3
 *  - default libgdx backend version
 * 	- discontinuation of lwjgl3
 * 	- better support for JREs, macOS, Linux and muti-window environments
 * https://libgdx.com/news/2021/07/devlog-7-lwjgl3